### PR TITLE
Setup fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 **__pycache__**
 .coverage
+build/
+*.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,11 @@ setup(
     author="Zumi Daxuya",
     author_email="daxuya.zumi+chipchune@proton.me",
     packages=[
-        "chipchune.furnace", "chipchune.famitracker", "chipchune.deflemask"
+        "chipchune",
+        "chipchune.deflemask",
+        "chipchune.famitracker",
+        "chipchune.furnace",
+        "chipchune.interchange",
     ],
     license="MIT",
     python_requires=">=3.8",


### PR DESCRIPTION
The setup.py file does not package all of the necessary files. Specifically, the root chipchune package is missing, breaking the _util imports. This adds the missing packages, and also adds build files to .gitignore.